### PR TITLE
chore(ci): enforce coverage gate at 8% (conservative estimate)

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -1,0 +1,26 @@
+name: ci/test
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install
+        run: |
+          python -m pip install -U pip
+          python -m pip install -e .[dev]
+      - name: Pytest (explicit gate)
+        run: |
+          pytest -p no:cacheprovider -o addopts="" --maxfail=1 \
+            --cov=src --cov-report=term --cov-report=xml \
+            --cov-fail-under=${{ env.COV_GATE }} \
+            universal_recon/tests tests -k "not slow and not e2e and not integration"
+    env:
+      COV_GATE: 8


### PR DESCRIPTION
Adds explicit --cov-fail-under=8 with deterministic pytest args.