### PR TITLE
chore(codespaces): verify hygiene; add pip cache mount + tasks palette

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -218,6 +218,7 @@
   "containerUser": "vscode",
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/bar-directory-recon,type=bind,consistency=cached",
   "workspaceFolder": "/workspaces/bar-directory-recon",
+  "mounts": ["source=${localEnv:USERPROFILE}\\.cache\\pip,target=/home/vscode/.cache/pip,type=bind"],
   "remoteEnv": {
     "PYTHONPATH": "/workspaces/bar-directory-recon/src:/workspaces/bar-directory-recon",
     "PYTHONDONTWRITEBYTECODE": "1",

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ desktop.ini
 .vscode/
 !.vscode/extensions.json          # keep shared extension list
 !.vscode/settings.example.json    # keep templated settings
+!.vscode/tasks.json               # keep shared tasks
 .idea/
 *.suo
 *.user

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,6 +2,46 @@
     "version": "2.0.0",
     "tasks": [
         {
+            "label": "Lint (Ruff)",
+            "type": "shell",
+            "command": "ruff check --fix .",
+            "group": "test",
+            "presentation": {
+                "reveal": "always",
+                "panel": "new"
+            }
+        },
+        {
+            "label": "Format (Black)",
+            "type": "shell",
+            "command": "black .",
+            "group": "test",
+            "presentation": {
+                "reveal": "always",
+                "panel": "new"
+            }
+        },
+        {
+            "label": "Test (quick)",
+            "type": "shell",
+            "command": "pytest",
+            "group": "test",
+            "presentation": {
+                "reveal": "always",
+                "panel": "new"
+            }
+        },
+        {
+            "label": "Test (cov)",
+            "type": "shell",
+            "command": "pytest --cov=src --cov-report=term-missing",
+            "group": "test",
+            "presentation": {
+                "reveal": "always",
+                "panel": "new"
+            }
+        },
+        {
             "label": "Run Automation Setup",
             "type": "shell",
             "command": "${command:python.interpreterPath}",


### PR DESCRIPTION
## Why
- Speed: Added pip cache mount for faster package installations
- UX: Added VS Code tasks palette with Ruff, Black, and pytest tasks

## What Changed
- Added pip cache mount to devcontainer.json
- Added/updated tasks.json with Lint (Ruff), Format (Black), Test (quick), and Test (cov) tasks
- Updated .gitignore to include tasks.json

## Acceptance Checks
- CHROME_BIN is set to /usr/bin/google-chrome (note: expected /usr/local/bin/chrome-no-sandbox)
- Pytest ran successfully
- Code coverage observed at 15.09%
