### PR TITLE
Fix test plugin fanout order dependency

### DIFF
--- a/tests/plugins/test_plugin_fanout.py
+++ b/tests/plugins/test_plugin_fanout.py
@@ -1,4 +1,5 @@
 def test_plugin_fanout_yields_record():
     from universal_recon.plugins import manager
-    out = list(manager.fanout({"q":"smoke"}))
-    assert out and out[0].get("example") is True
+
+    out = list(manager.fanout({"q": "smoke"}))
+    assert any(record.get("example") is True for record in out)


### PR DESCRIPTION
## Why
The test for plugin fanout had a non-deterministic order dependency across plugins, causing test fragility.

## What Changed
Modified the assertion to use  over the result list instead of assuming first result would always be from an example plugin.

## Acceptance
- Pytest runs successfully with this change
- Test is now more deterministic and robust