### PR TITLE
Add stale workflow for issues and pull requests

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,27 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '25 19 * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'Stale issue message'
+        stale-pr-message: 'Stale pull request message'
+        stale-issue-label: 'no-issue-activity'
+        stale-pr-label: 'no-pr-activity'


### PR DESCRIPTION
This workflow automatically marks stale issues and pull requests based on inactivity, helping to manage repository activity.

﻿## Summary
_Short description of the change._

## Type
- [ ] chore | dx | docs | fix | feat

## Checklist
- [ ] Paths limited to automation/monitoring/docs/tools
- [ ] Pre-commit passed locally
- [ ] Tests + coverage gate green
- [ ] Fast tests pass: `pytest -k "not slow and not e2e and not integration"`
- [ ] No secrets added (baseline clean)
- [ ] No secrets in logs or code

## Acceptance checks
_Add 2-4 bullets for what "done" means._

