### PR TITLE
chore(ci): add concurrency to fast-tests & audit

### DIFF
--- a/.github/workflows/fast-parity-ci.yml
+++ b/.github/workflows/fast-parity-ci.yml
@@ -3,6 +3,11 @@ on:
   pull_request:
   push:
     branches: [ main ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -3,6 +3,11 @@ on:
   pull_request:
   push:
     branches: [ main ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write


### PR DESCRIPTION
Adds top-level concurrency to cancel redundant runs while preserving the 3 required checks.