### PR TITLE
ci(ps-lint): always-run (remove paths filter)

### DIFF
--- a/.github/workflows/ps-lint.yml
+++ b/.github/workflows/ps-lint.yml
@@ -2,8 +2,6 @@ name: ps-lint
 on:
   pull_request:
     branches: [ main ]
-    paths:
-      - "scripts/**"
 jobs:
   ps-lint:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Removes pull_request.paths from ps-lint.yml so it runs on all PRs. Names unchanged; no policy change.