### PR TITLE
ci(hygiene): schedule-only + rename

### DIFF
--- a/.github/workflows/ci-hygiene-weekly.yml
+++ b/.github/workflows/ci-hygiene-weekly.yml
@@ -1,9 +1,12 @@
-name: pr-hygiene-report
+name: ci-hygiene-weekly
 on:
   schedule:
-    # 14:10 UTC daily (safe cadence); adjustable
-    - cron: "10 14 * * *"
+    - cron: "30 13 * * 3"  # Wed 09:30 ET
   workflow_dispatch:
+
+concurrency:
+  group: ci-hygiene-weekly
+  cancel-in-progress: true
 
 permissions:
   contents: read


### PR DESCRIPTION
Convert pr-hygiene-report to schedule + workflow_dispatch; optional rename to ci-hygiene-weekly; no policy change.