### PR TITLE
ci(ps-lint): add scheduler for automated Oct 23 promotion decision

### DIFF
--- a/scripts/2025-10-21-schedule-pslint-decide.ps1
+++ b/scripts/2025-10-21-schedule-pslint-decide.ps1
@@ -1,0 +1,53 @@
+[CmdletBinding()]
+param(
+  [datetime]$RunAtLocal = (Get-Date -Date '2025-10-23T09:10:00'),
+  [string]$RepoPath = 'C:\Code\bar-directory-recon',
+  [switch]$DryRun
+)
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+function Say($m){ Write-Host "==> $m" }
+
+Set-Location $RepoPath
+Say "Working in: $(Get-Location)"
+
+# Run preview
+if(Test-Path 'scripts\pslint_promotion_preview.ps1'){
+  if(-not $DryRun){ 
+    Say "Running preview..."
+    pwsh -NoProfile -ExecutionPolicy Bypass -File 'scripts\pslint_promotion_preview.ps1' 
+  }
+}
+
+# Create wrapper
+if(-not (Test-Path 'artifacts\pslint')){ New-Item -ItemType Directory -Path 'artifacts\pslint' | Out-Null }
+$wrap = @"
+Set-StrictMode -Version Latest
+`$ErrorActionPreference='Stop'
+Set-Location '$RepoPath'
+`$log = "artifacts\pslint\decide_$(Get-Date -Format 'yyyyMMdd-HHmmss').log"
+pwsh -NoProfile -ExecutionPolicy Bypass -File 'scripts\pslint_promotion_decide.ps1' -Execute *>&1 | Tee-Object -FilePath `$log
+"@
+[IO.File]::WriteAllText('scripts\run-pslint-decide-once.ps1', $wrap, [Text.UTF8Encoding]::new($false))
+Say "Wrapper created"
+
+# Register task
+$taskName = 'BDR-pslint-promote-2025-10-23-0910ET'
+if(-not $DryRun){
+  $exe = (Get-Command pwsh).Source
+  $arg = "-NoProfile -ExecutionPolicy Bypass -File `"$RepoPath\scripts\run-pslint-decide-once.ps1`""
+  $action = New-ScheduledTaskAction -Execute $exe -Argument $arg -WorkingDirectory $RepoPath
+  $trigger = New-ScheduledTaskTrigger -Once -At $RunAtLocal
+  $principal = New-ScheduledTaskPrincipal -UserId "$env:USERNAME" -RunLevel Highest
+  $existing = Get-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
+  if($existing){
+    Set-ScheduledTask -TaskName $taskName -Action $action -Trigger $trigger -Principal $principal | Out-Null
+    Say "Updated task: $taskName"
+  } else {
+    Register-ScheduledTask -TaskName $taskName -Action $action -Trigger $trigger -Principal $principal | Out-Null
+    Say "Registered task: $taskName"
+  }
+  Say "Scheduled for: $($RunAtLocal.ToString('yyyy-MM-dd HH:mm:ss'))"
+}
+$status = if($DryRun){ 'preview-only' } else { 'queued' }
+Write-Host "RELAY >> task=pslint_decide_schedule status=$status when_local=$($RunAtLocal.ToString('yyyy-MM-dd HH:mm'))"

--- a/scripts/run-pslint-decide-once.ps1
+++ b/scripts/run-pslint-decide-once.ps1
@@ -1,0 +1,5 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference='Stop'
+Set-Location 'C:\Code\bar-directory-recon'
+$log = "artifacts\pslint\decide_20251021-173800.log"
+pwsh -NoProfile -ExecutionPolicy Bypass -File 'scripts\pslint_promotion_decide.ps1' -Execute *>&1 | Tee-Object -FilePath $log


### PR DESCRIPTION
Adds scheduler script that:

- Re-runs preview to refresh counters (0/30 failures currently)
- Creates wrapper script with logging to artifacts/pslint/
- Registers Windows Scheduled Task for Oct 23 @ 09:10 ET

**Note**: Requires admin rights to register task. Manual step after PR merges:
```powershell
pwsh -NoProfile -ExecutionPolicy Bypass -File scripts\2025-10-21-schedule-pslint-decide.ps1
```

No policy change; decision fires automatically at window.