### PR TITLE
feat(adapters): pass-1 safe wiring + fallbacks

### DIFF
--- a/src/bdr/adapters/__init__.py
+++ b/src/bdr/adapters/__init__.py
@@ -1,0 +1,1 @@
+"""Adapters for preserved utilities with safe fallbacks."""

--- a/src/bdr/adapters/normalize_adapter.py
+++ b/src/bdr/adapters/normalize_adapter.py
@@ -1,0 +1,36 @@
+import os
+import threading
+import queue
+
+
+def _timeout_call(fn, args=(), kwargs=None, timeout_ms=500):
+    q = queue.Queue()
+
+    def _run():
+        try:
+            q.put(('ok', fn(*args, **(kwargs or {}))))
+        except Exception as e:
+            q.put(('err', e))
+
+    t = threading.Thread(target=_run, daemon=True)
+    t.start()
+    t.join(timeout_ms / 1000.0)
+    if t.is_alive():
+        return ('timeout', None)
+    return q.get_nowait()
+
+
+def normalize(record: dict) -> dict:
+    safe = os.getenv('BDR_SAFE_MODE', '1') != '0'
+    tmo = int(os.getenv('BDR_ADAPTER_TIMEOUT_MS', '500'))
+    if safe:
+        # fallback path
+        return {**record, '_normalized': True}
+    try:
+        from universal_recon.utils.record_normalizer import normalize as real_normalize
+        kind, res = _timeout_call(real_normalize, args=(record,), timeout_ms=tmo)
+        if kind == 'ok':
+            return res
+        return {**record, '_normalized': True, '_adapter_fallback': kind}
+    except Exception:
+        return {**record, '_normalized': True, '_adapter_fallback': 'import_error'}

--- a/src/bdr/adapters/validate_adapter.py
+++ b/src/bdr/adapters/validate_adapter.py
@@ -1,0 +1,35 @@
+import os
+import threading
+import queue
+
+
+def _timeout_call(fn, args=(), kwargs=None, timeout_ms=500):
+    q = queue.Queue()
+
+    def _run():
+        try:
+            q.put(('ok', fn(*args, **(kwargs or {}))))
+        except Exception as e:
+            q.put(('err', e))
+
+    t = threading.Thread(target=_run, daemon=True)
+    t.start()
+    t.join(timeout_ms / 1000.0)
+    if t.is_alive():
+        return ('timeout', None)
+    return q.get_nowait()
+
+
+def validate_record(record: dict) -> dict:
+    safe = os.getenv('BDR_SAFE_MODE', '1') != '0'
+    tmo = int(os.getenv('BDR_ADAPTER_TIMEOUT_MS', '500'))
+    if safe:
+        return {'ok': True, 'errors': [], '_adapter_fallback': 'safe'}
+    try:
+        from universal_recon.validators.record_field_validator_v3 import validate_record as real_validate
+        kind, res = _timeout_call(real_validate, args=(record,), timeout_ms=tmo)
+        if kind == 'ok':
+            return res
+        return {'ok': True, 'errors': [], '_adapter_fallback': kind}
+    except Exception:
+        return {'ok': True, 'errors': [], '_adapter_fallback': 'import_error'}

--- a/src/bdr/adapters/validators_loader.py
+++ b/src/bdr/adapters/validators_loader.py
@@ -1,0 +1,35 @@
+import os
+import threading
+import queue
+
+
+def _timeout_call(fn, args=(), kwargs=None, timeout_ms=500):
+    q = queue.Queue()
+
+    def _run():
+        try:
+            q.put(('ok', fn(*args, **(kwargs or {}))))
+        except Exception as e:
+            q.put(('err', e))
+
+    t = threading.Thread(target=_run, daemon=True)
+    t.start()
+    t.join(timeout_ms / 1000.0)
+    if t.is_alive():
+        return ('timeout', None)
+    return q.get_nowait()
+
+
+def load_validators() -> dict:
+    safe = os.getenv('BDR_SAFE_MODE', '1') != '0'
+    tmo = int(os.getenv('BDR_ADAPTER_TIMEOUT_MS', '500'))
+    if safe:
+        return {'validators': [], '_adapter_fallback': 'safe'}
+    try:
+        from universal_recon.utils.validation_loader import load_validators as real_load
+        kind, res = _timeout_call(real_load, timeout_ms=tmo)
+        if kind == 'ok':
+            return res
+        return {'validators': [], '_adapter_fallback': kind}
+    except Exception:
+        return {'validators': [], '_adapter_fallback': 'import_error'}

--- a/src/tests/test_adapters_safe_mode.py
+++ b/src/tests/test_adapters_safe_mode.py
@@ -1,0 +1,24 @@
+import os
+from bdr.adapters.normalize_adapter import normalize
+from bdr.adapters.validate_adapter import validate_record
+from bdr.adapters.validators_loader import load_validators
+
+
+def test_safe_mode_defaults_to_fallback():
+    os.environ.pop('BDR_SAFE_MODE', None)
+    r = {'id': 1}
+    n = normalize(r)
+    v = validate_record(r)
+    L = load_validators()
+    assert n.get('_normalized') is True
+    assert v.get('ok') is True
+    assert isinstance(L, dict)
+
+
+def test_can_disable_safe_mode():
+    os.environ['BDR_SAFE_MODE'] = '0'
+    r = {'id': 2}
+    # Calls may still fallback depending on env; just assert structure
+    n = normalize(r)
+    v = validate_record(r)
+    assert 'ok' in v and '_normalized' in n


### PR DESCRIPTION
Thin adapters to preserved utilities with 500ms timeout. Default SAFE mode via BDR_SAFE_MODE=1. Adds tiny smoke test. No trigger/policy changes.