### PR TITLE
chore: 0.1.1.dev0 bump + docs (adapters env toggles)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- **Adapters Pass-1**: Thin adapters to preserved utilities (`normalize`, `validate_record`, `load_validators`) with 500ms timeout and safe fallbacks.
+- **Safe Mode**: `BDR_SAFE_MODE` (default `1`) enables no-op fallbacks; set to `0` to attempt real imports.
+- **Configurable Timeout**: `BDR_ADAPTER_TIMEOUT_MS` (default `500`) controls per-call timeout when safe mode is disabled.
+
+## [v0.1.0] - 2025-10-27
+
+### Added
+- Initial stable release with 6 required CI checks (audit, fast-tests ubuntu/windows, workflow-guard, ps-lint ubuntu/windows)
+- CLI demo with ingest/normalize/validate/score/report commands
+- Security quieting and locked dependencies
+
 ## [v2.0-cross-device] - 2025-08-06 - Phase 2 Cross-Device Parity Close-Out (ASUS)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -75,6 +75,24 @@ bdr report   -i examples/demo/work/score.json -o examples/demo/output/report.jso
 - **Adapters are safe**: if preserved utilities aren't importable or signatures differ, the CLI falls back to the current no-op behavior so CI stays green.
 - See `configs/` for the schema/fieldmap/rules placeholders used by the demo.
 
+### Adapters (Safe Mode)
+
+Adapters prefer preserved utilities when available, with a timeout fallback.
+
+- `BDR_SAFE_MODE` (default `1`): when `1`, adapters use safe fallbacks (no external imports).
+- `BDR_ADAPTER_TIMEOUT_MS` (default `500`): per-call timeout when safe mode is `0`.
+
+Examples:
+```bash
+# default (safe)
+bdr doctor
+
+# try real adapters with 1s timeout
+set BDR_SAFE_MODE=0
+set BDR_ADAPTER_TIMEOUT_MS=1000
+bdr run ...
+```
+
 ---
 
 ## Cross-Device Bootstrap

--- a/src/bdr/__init__.py
+++ b/src/bdr/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ['cli']
-__version__ = '0.1.0'
+__version__ = '0.1.1.dev0'


### PR DESCRIPTION
Post-release housekeeping after v0.1.0 publish and adapters pass-1 merge.

### Changes
- Bump version: 0.1.0 → 0.1.1.dev0
- CHANGELOG: Add [Unreleased] section with adapters pass-1 details
- README: Document BDR_SAFE_MODE and BDR_ADAPTER_TIMEOUT_MS env variables

### Notes
- Docs-only + version bump
- No workflows/policies changed
- All tests pass locally