### PR TITLE
ci: cli-pack - add checksum files (.sha256) to Release and artifacts

### DIFF
--- a/.github/workflows/cli-pack.yml
+++ b/.github/workflows/cli-pack.yml
@@ -17,13 +17,18 @@ jobs:
         run: pip install build
       - name: Build wheel & sdist
         run: python -m build
-      - name: Upload to Release (if release)
+      
+      - name: Generate checksums
+        run: |
+          for f in dist/*; do sha256sum "$f" > "$f.sha256"; done
+- name: Upload to Release (if release)
         if: github.event_name == 'release'
         uses: softprops/action-gh-release@v2
         with:
           files: |
             dist/*.whl
             dist/*.tar.gz
+            dist/*.sha256
       - name: Upload artifact (if manual)
         if: github.event_name != 'release'
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Generate SHA256 for dist/* and upload to Release (and manual artifacts). Guard-safe: only release/dispatch triggers.