### PR TITLE
fix(ci): ensure PSGallery is registered before setting policy in ps-lint

### DIFF
--- a/.github/workflows/ps-lint.yml
+++ b/.github/workflows/ps-lint.yml
@@ -34,6 +34,13 @@ jobs:
         if: steps.changed.outputs.has_scripts == 'true'
         shell: pwsh
         run: pwsh -NoProfile -File scripts/apply-attic-review.ps1 -DryRun -PrNumber 0
+      - name: Ensure PSGallery is registered
+        if: steps.changed.outputs.has_scripts == 'true'
+        shell: pwsh
+        run: |
+          if (-not (Get-PSRepository -Name 'PSGallery' -ErrorAction SilentlyContinue)) {
+            Register-PSRepository -Name 'PSGallery' -SourceLocation 'https://www.powershellgallery.com/api/v2/' -InstallationPolicy Trusted
+          }
       - name: Install PSScriptAnalyzer
         if: steps.changed.outputs.has_scripts == 'true'
         shell: pwsh


### PR DESCRIPTION
## Problem

The ps-lint workflow fails on Ubuntu runners with:
```
cannot find a repository named 'PSGallery'
```n
## Root Cause

Ubuntu runners don't have PSGallery pre-registered, but the workflow tries to run `Set-PSRepository PSGallery -InstallationPolicy Trusted` without checking if it exists.

## Solution

Added a new step `Ensure PSGallery is registered` that:
- Checks if PSGallery repository exists
- Registers it if missing with InstallationPolicy Trusted
- Runs before the PSScriptAnalyzer installation step

## Impact
- ✅ Fixes ps-lint failures on Ubuntu runners
- ✅ No impact on Windows runners (PSGallery already registered)
- ✅ Guard-safe: only affects ps-lint workflow
- ✅ Follows GitHub Copilot recommendation

## Testing

This PR will validate the fix when ps-lint runs against scripts/ changes.