### PR TITLE
ci(hector): manual PyPI publisher + Insights signals

### DIFF
--- a/.github/workflows/insights-testpypi-line.yml
+++ b/.github/workflows/insights-testpypi-line.yml
@@ -1,0 +1,39 @@
+name: insights-testpypi-line
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '30 14 * * 3'  # Wed 09:30 ET
+
+jobs:
+  insights:
+    name: Insights signals
+    runs-on: ubuntu-latest
+    steps:
+      - name: Compute parity/pack signals
+        id: signals
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const {owner, repo} = context.repo;
+            async function latest(workflow){ try { const r = await github.rest.actions.listWorkflowRuns({owner, repo, workflow_id: workflow, per_page:1}); return r.data.workflow_runs[0]; } catch(e){ return null; } }
+            const runPack = await latest('cli-pack.yml');
+            let windows='unknown', ubuntu='unknown', last_ok='unknown';
+            if (runPack) {
+              const jobs = await github.rest.actions.listJobsForWorkflowRun({owner, repo, run_id: runPack.id});
+              for (const j of jobs.data.jobs) {
+                const name = (j.name||'').toLowerCase();
+                if (name.includes('windows')) windows = j.conclusion === 'success' ? 'pass' : 'fail';
+                if (name.includes('ubuntu'))  ubuntu  = j.conclusion === 'success' ? 'pass' : 'fail';
+              }
+              if (runPack.conclusion === 'success') last_ok = runPack.updated_at;
+            }
+            const runParity = await latest('release-qa-parity.yml');
+            const parity_link = runParity?.html_url || 'unknown';
+            core.setOutput('pack_smoke_summary', windows=\ ubuntu=\ last_ok=\);
+            core.setOutput('parity_link', parity_link);
+
+      - name: Append Insights signals
+        shell: pwsh
+        run: |
+          "$pack = ${{ steps.signals.outputs.pack_smoke_summary }}" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          "$parity = parity_link: ${{ steps.signals.outputs.parity_link }}" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,38 @@
+name: publish-pypi
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (tag or branch)"
+        required: true
+        default: "0.1.1"
+        type: string
+      skip_existing:
+        description: "Skip files already on PyPI"
+        required: true
+        default: true
+        type: boolean
+
+jobs:
+  publish:
+    name: publish to PyPI (manual)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.version }}
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Build
+        run: |
+          python -m pip install --upgrade pip build twine
+          python -m build
+          twine check dist/*
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          skip-existing: ${{ inputs.skip_existing }}


### PR DESCRIPTION
Hector alignment:
- Ensure **publish-pypi.yml** (manual-only): workflow_dispatch inputs version=0.1.1, skip_existing=true; build → twine check → pypa/gh-action-pypi-publish.
- Add **Insights signals** to insights-testpypi-line:
  * pack_smoke_summary: windows=<pass/fail> ubuntu=<pass/fail> last_ok=<UTC ts>
  * parity_link: <latest release-qa-parity run URL>

Guard-safe (no push/PR triggers). No required checks changed.