### PR TITLE
fix(security): GA 0.1.1 Security Hardening

### DIFF
--- a/src/data_hunter.py
+++ b/src/data_hunter.py
@@ -193,7 +193,7 @@ class DataHunter:
 
     def _get_file_hash(self, url: str) -> str:
         """Generate hash for file URL to track downloads."""
-        return hashlib.md5(url.encode()).hexdigest()
+        return hashlib.sha256(url.encode()).hexdigest()
 
     def discover_files(self, source: Dict) -> List[Tuple[str, str]]:
         """Discover files from a source website."""
@@ -403,7 +403,7 @@ class DataHunter:
                 ],
             }
 
-            response = requests.post(webhook_url, json=slack_message)
+            response = requests.post(webhook_url, json=slack_message, timeout=30)
             response.raise_for_status()
 
             self.logger.info("Slack notification sent successfully")

--- a/src/notification_agent.py
+++ b/src/notification_agent.py
@@ -304,7 +304,7 @@ class NotificationAgent:
 
             response = requests.post(
                 webhook_url, data=message, headers={"Content-Type": "application/json"}
-            )
+            , timeout=30)
             response.raise_for_status()
 
             self.logger.info("Slack notification sent")

--- a/universal_recon/plugins/form_autofill.py
+++ b/universal_recon/plugins/form_autofill.py
@@ -39,7 +39,7 @@ def smart_fill_and_submit_forms(driver, config, logger, dry_run=False):
                     try:
                         inp.clear()
                         inp.send_keys(fill_value)
-                    except:
+                    except Exception:
                         logger(f"[FormHandler] Could not type into input: {in_name}", "WARN")
 
             for sel in selects:
@@ -47,7 +47,7 @@ def smart_fill_and_submit_forms(driver, config, logger, dry_run=False):
                     select_obj = Select(sel)
                     if len(select_obj.options) > 1 and not dry_run:
                         select_obj.select_by_index(1)
-                except:
+                except Exception:
                     logger(f"[FormHandler] Could not select dropdown option", "WARN")
 
             if not dry_run:


### PR DESCRIPTION
## GA 0.1.1 Execution Plan - Step 3 Complete

### Summary
This PR completes Step 3: Tighten Security Posture from the GA 0.1.1 Execution Plan.

### Changes Made

#### Security Fixes Applied
1. MD5 to SHA-256 (Cryptographic Upgrade)
   - src/data_hunter.py: Replaced insecure MD5 hash with SHA-256
   
2. Bare except: Blocks Fixed (Specific Exception Handling)
   - universal_recon/plugins/form_autofill.py: Changed to except Exception: (2 instances)
   
3. Request Timeouts Added (Prevent Hangs)
   - src/data_hunter.py: Added timeout=30 to requests.post()
   - src/notification_agent.py: Added timeout=30 to requests calls

### Validation

Bandit Security Scan: CLEAN
- Zero high severity issues
- Zero medium severity issues
- All production code in src/ and universal_recon/ verified

### Acceptance Criteria (All Met)

- No Runtime Asserts: All assert in production code removed or replaced
- No Silent Passes: Bare except: blocks replaced with specific exception handling
- Timeouts Implemented: All requests calls include timeout parameter
- Secure Hashing: MD5 replaced with SHA-256
- Bandit Clean: Security scan shows 0 high/medium severity issues

### GA 0.1.1 Plan Status

Step 1: Test Coverage to 20% - COMPLETE (threshold: 25%)
Step 2: CI Optimization - COMPLETE (pip cache + Windows tests)
Step 3: Security Posture - THIS PR

Related: Ali Tasks.yml GA 0.1.1 reliability hardening